### PR TITLE
Adding Sortable Table

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -35,19 +35,19 @@ msgstr ""
 msgid "No Geometry"
 msgstr ""
 
-msgid "Name"	
-msgstr ""	
+msgid "Name"
+msgstr ""
 
-msgid "UID"	
-msgstr ""	
+msgid "UID"
+msgstr ""
 
-msgid "Level"	
-msgstr ""	
+msgid "Level"
+msgstr ""
 
-msgid "Users"	
-msgstr ""	
+msgid "Users"
+msgstr ""
 
-msgid "Geometry Type"	
+msgid "Geometry Type"
 msgstr ""
 
 msgid "NONE"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,13 +5,16 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-02T16:58:40.174Z\n"
-"PO-Revision-Date: 2020-10-02T16:58:40.174Z\n"
+"POT-Creation-Date: 2020-10-11T00:27:16.658Z\n"
+"PO-Revision-Date: 2020-10-11T00:27:16.658Z\n"
 
 msgid "An error occurred!"
 msgstr ""
 
 msgid "Loading..."
+msgstr ""
+
+msgid "No results found for"
 msgstr ""
 
 msgid "Previous"
@@ -30,21 +33,6 @@ msgid "All"
 msgstr ""
 
 msgid "No Geometry"
-msgstr ""
-
-msgid "Name"
-msgstr ""
-
-msgid "UID"
-msgstr ""
-
-msgid "Level"
-msgstr ""
-
-msgid "Users"
-msgstr ""
-
-msgid "Geometry Type"
 msgstr ""
 
 msgid "NONE"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -35,6 +35,21 @@ msgstr ""
 msgid "No Geometry"
 msgstr ""
 
+msgid "Name"	
+msgstr ""	
+
+msgid "UID"	
+msgstr ""	
+
+msgid "Level"	
+msgstr ""	
+
+msgid "Users"	
+msgstr ""	
+
+msgid "Geometry Type"	
+msgstr ""
+
 msgid "NONE"
 msgstr ""
 

--- a/i18n/fr.po
+++ b/i18n/fr.po
@@ -61,3 +61,6 @@ msgstr "Unités d'Org sur l'Île Nulle"
 
 msgid "Overview"
 msgstr "Aperçu"
+
+msgid "No results found for"
+msgstr "Aucun résultat trouvé pour"

--- a/src/components/OrgUnitSection/FilteredOrgUnitTable.js
+++ b/src/components/OrgUnitSection/FilteredOrgUnitTable.js
@@ -39,7 +39,7 @@ function FilteredOrgUnitTable({ search, filter, order }) {
                 search,
                 filter,
                 page: 1,
-                order
+                order,
             })
         } else {
             isFirstRender.current = false
@@ -53,16 +53,18 @@ function FilteredOrgUnitTable({ search, filter, order }) {
     if (!data) {
         return i18n.t('Loading...')
     }
-    if (data?.orgUnits?.organisationUnits.length < 1){
+    if (data?.orgUnits?.organisationUnits.length < 1) {
         return `${i18n.t('No results found for')} '${search}'.`
     }
-
 
     return (
         <>
             <div className={styles.tableContainer}>
                 {loading && <ComponentCover translucent />}
-                <OrgUnitTable orgUnits={data.orgUnits.organisationUnits} orderBy={refetch} />
+                <OrgUnitTable
+                    orgUnits={data.orgUnits.organisationUnits}
+                    orderBy={refetch}
+                />
             </div>
             <div className={styles.tableFooter}>
                 <Button
@@ -102,6 +104,7 @@ function FilteredOrgUnitTable({ search, filter, order }) {
 
 FilteredOrgUnitTable.propTypes = {
     filter: PropTypes.string,
+    order: PropTypes.string,
     search: PropTypes.string,
 }
 

--- a/src/components/OrgUnitSection/FilteredOrgUnitTable.js
+++ b/src/components/OrgUnitSection/FilteredOrgUnitTable.js
@@ -10,10 +10,11 @@ import styles from './OrgUnitSection.module.css'
 const query = {
     orgUnits: {
         resource: 'organisationUnits',
-        params: ({ page, search, filter }) => {
+        params: ({ page, search, filter, order }) => {
             return {
                 pageSize: 5,
                 page: page,
+                order: order,
                 fields: ['id', 'displayName', 'level', 'geometry'],
                 filter: search
                     ? `displayName:ilike:${search}`
@@ -25,7 +26,7 @@ const query = {
     },
 }
 
-function FilteredOrgUnitTable({ search, filter }) {
+function FilteredOrgUnitTable({ search, filter, order }) {
     const [data, setData] = useState(undefined)
     const { loading, error, refetch } = useDataQuery(query, {
         onComplete: setData,
@@ -38,6 +39,7 @@ function FilteredOrgUnitTable({ search, filter }) {
                 search,
                 filter,
                 page: 1,
+                order
             })
         } else {
             isFirstRender.current = false
@@ -51,12 +53,16 @@ function FilteredOrgUnitTable({ search, filter }) {
     if (!data) {
         return i18n.t('Loading...')
     }
+    if (data?.orgUnits?.organisationUnits.length < 1){
+        return `${i18n.t('No results found for')} '${search}'.`
+    }
+
 
     return (
         <>
             <div className={styles.tableContainer}>
                 {loading && <ComponentCover translucent />}
-                <OrgUnitTable orgUnits={data.orgUnits.organisationUnits} />
+                <OrgUnitTable orgUnits={data.orgUnits.organisationUnits} orderBy={refetch} />
             </div>
             <div className={styles.tableFooter}>
                 <Button

--- a/src/components/OrgUnitSection/OrgUnitSection.module.css
+++ b/src/components/OrgUnitSection/OrgUnitSection.module.css
@@ -1,44 +1,53 @@
 .container {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    font-size: 1rem;
-  }
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  font-size: 1rem;
+}
 
-  .controls {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    margin: 0 0 16px 0;
-  }
-  
-  .controls > div {
-    margin: 0 32px 0 0;
-  }
+.controls {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 0 0 16px 0;
+}
 
-  .controls > label {
-    margin: 0 16px 0 0;
-  }
+.controls > div {
+  margin: 0 32px 0 0;
+}
 
-  .tableContainer {
-    position: relative;
-  }
+.controls > label {
+  margin: 0 16px 0 0;
+}
 
-  .table {
-    width: 640px;
-  }
+.tableContainer {
+  position: relative;
+}
 
-  .stretchCell {
-    width: 100%;
-  }
+.table {
+  width: 640px;
+}
 
-  .tableFooter {
-    width: 100%;
-    text-align: center;
-    margin: 16px 0 0;
-  }
+.stretchCell {
+  width: 100%;
+}
 
-  .pageCountDiv {
-    margin: 0 8px;
-  }
+.tableFooter {
+  width: 100%;
+  text-align: center;
+  margin: 16px 0 0;
+}
+
+.pageCountDiv {
+  margin: 0 8px;
+}
+
+.columnHeader {
+  cursor: pointer;
+}
+
+.sortArrow {
+  font-size: 0.6rem;
+  margin-left: 4px;
+}

--- a/src/components/OrgUnitSection/OrgUnitTable.js
+++ b/src/components/OrgUnitSection/OrgUnitTable.js
@@ -18,22 +18,25 @@ import styles from './OrgUnitSection.module.css'
 
 export const OrgUnitTable = ({ orgUnits, orderBy }) => {
     const { baseUrl } = useConfig()
-    const [order, setOrder] = useState('asc')
+    const [order, setOrder] = useState({ column: 'displayName', direction: 1 })
 
     const handleHeaderClick = field => {
-        // There's probably a simpler way to do this...just going between acedning and descending for the query
-        setOrder(order === 'asc' ? 'desc' : order === 'desc' ? 'asc' : 'desc')
-        //orderBy is actually our refetch paginated query/function we pass down as props
-        orderBy({ order: `${field}:${order}` })
+        if (order.column === field) {
+            setOrder({ column: field, direction: order.direction * -1 })
+        } else {
+            setOrder({ column: field, direction: 1 })
+        }
+
+        const direction = order.direction > 0 ? 'asc' : 'desc'
+        orderBy({ order: `${order.field}:${direction}` })
     }
 
     const tableHeaders = [
-        { display: 'Name', field: 'displayName' },
-        { display: 'UID', field: 'id' },
-        { display: 'Level', field: 'level' },
-        // {display: 'Users',
-        // field: 'Users'},
-        { display: 'Geometry Type', field: 'geometry' },
+        { display: i18n.t('Name'), field: 'displayName' },
+        { display: i18n.t('UID'), field: 'id' },
+        { display: i18n.t('Level'), field: 'level' },
+        // {display: i18n.t('Users'), field: 'Users'},
+        { display: i18n.t('Geometry Type'), field: 'geometry' },
     ]
 
     return (
@@ -49,7 +52,7 @@ export const OrgUnitTable = ({ orgUnits, orderBy }) => {
                                             handleHeaderClick(header.field)
                                         }
                                     >
-                                        {i18n.t(header.display)}
+                                        {header.display}
                                     </span>
                                 </TableCellHead>
                             ))}

--- a/src/components/OrgUnitSection/OrgUnitTable.js
+++ b/src/components/OrgUnitSection/OrgUnitTable.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { useConfig } from '@dhis2/app-runtime'
 import {
@@ -16,23 +16,37 @@ import { UserCount } from './UserCount'
 
 import styles from './OrgUnitSection.module.css'
 
-export const OrgUnitTable = ({ orgUnits }) => {
+export const OrgUnitTable = ({ orgUnits, orderBy }) => {
     const { baseUrl } = useConfig()
+    const [order, setOrder] = useState('asc');
+
+    const handleHeaderClick = (field) => {
+        // There's probably a simpler way to do this...just going between acedning and descending for the query
+        setOrder(order === 'asc' ? 'desc' : order === 'desc' ? 'asc': 'desc')
+        //orderBy is actually our refetch paginated query/function we pass down as props
+        orderBy({order: `${field}:${order}` })
+    }
+
+    const tableHeaders = [
+        {display: 'Name',
+        field: 'displayName'},
+        {display: 'UID',
+        field: 'id'},
+        {display: 'Level',
+        field: 'level'},
+        // {display: 'Users',
+        // field: 'Users'},
+        {display: 'Geometry Type',
+        field: 'geometry'}
+    ];
+
     return (
         <>
             {orgUnits.length ? (
                 <Table className={styles.table}>
                     <TableHead>
                         <TableRowHead>
-                            <TableCellHead className={styles.stretchCell}>
-                                {i18n.t('Name')}
-                            </TableCellHead>
-                            <TableCellHead>{i18n.t('UID')}</TableCellHead>
-                            <TableCellHead>{i18n.t('Level')}</TableCellHead>
-                            <TableCellHead>{i18n.t('Users')}</TableCellHead>
-                            <TableCellHead>
-                                {i18n.t('Geometry Type')}
-                            </TableCellHead>
+                            {tableHeaders.map(header => <TableCellHead><span onClick={()=> handleHeaderClick(header.field)}>{i18n.t(header.display)}</span></TableCellHead>)}
                             <TableCellHead></TableCellHead>
                         </TableRowHead>
                     </TableHead>
@@ -43,9 +57,9 @@ export const OrgUnitTable = ({ orgUnits }) => {
                                     <TableCell>{orgUnit.displayName}</TableCell>
                                     <TableCell>{orgUnit.id}</TableCell>
                                     <TableCell>{orgUnit.level}</TableCell>
-                                    <TableCell>
+                                    {/* <TableCell>
                                         <UserCount orgUnitID={orgUnit.id} />
-                                    </TableCell>
+                                    </TableCell> */}
                                     <TableCell>
                                         {orgUnit.geometry
                                             ? orgUnit.geometry.type

--- a/src/components/OrgUnitSection/OrgUnitTable.js
+++ b/src/components/OrgUnitSection/OrgUnitTable.js
@@ -16,19 +16,28 @@ import i18n from '@dhis2/d2-i18n'
 
 import styles from './OrgUnitSection.module.css'
 
+const SortArrow = ({ direction }) =>
+    direction > 0 ? (
+        <span className={styles.sortArrow}>&#9660;</span>
+    ) : (
+        <span className={styles.sortArrow}>&#9650;</span>
+    )
+
+SortArrow.propTypes = {
+    direction: PropTypes.number.isRequired,
+}
+
 export const OrgUnitTable = ({ orgUnits, orderBy }) => {
     const { baseUrl } = useConfig()
     const [order, setOrder] = useState({ column: 'displayName', direction: 1 })
 
-    const handleHeaderClick = field => {
-        if (order.column === field) {
-            setOrder({ column: field, direction: order.direction * -1 })
-        } else {
-            setOrder({ column: field, direction: 1 })
-        }
+    const handleHeaderClick = column => {
+        const direction = order.column === column ? order.direction * -1 : 1
 
-        const direction = order.direction > 0 ? 'asc' : 'desc'
-        orderBy({ order: `${order.field}:${direction}` })
+        setOrder({ column, direction })
+
+        const directionStr = direction > 0 ? 'asc' : 'desc'
+        orderBy({ order: `${column}:${directionStr}` })
     }
 
     const tableHeaders = [
@@ -46,14 +55,22 @@ export const OrgUnitTable = ({ orgUnits, orderBy }) => {
                     <TableHead>
                         <TableRowHead>
                             {tableHeaders.map(header => (
-                                <TableCellHead key={header.field}>
-                                    <span
+                                <TableCellHead
+                                    key={header.field}
+                                    className={styles.columnHeader}
+                                >
+                                    <div
                                         onClick={() =>
                                             handleHeaderClick(header.field)
                                         }
                                     >
                                         {header.display}
-                                    </span>
+                                        {header.field === order.column ? (
+                                            <SortArrow
+                                                direction={order.direction}
+                                            />
+                                        ) : null}
+                                    </div>
                                 </TableCellHead>
                             ))}
                             <TableCellHead></TableCellHead>

--- a/src/components/OrgUnitSection/OrgUnitTable.js
+++ b/src/components/OrgUnitSection/OrgUnitTable.js
@@ -12,33 +12,29 @@ import {
     Button,
 } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
-import { UserCount } from './UserCount'
+// import { UserCount } from './UserCount'
 
 import styles from './OrgUnitSection.module.css'
 
 export const OrgUnitTable = ({ orgUnits, orderBy }) => {
     const { baseUrl } = useConfig()
-    const [order, setOrder] = useState('asc');
+    const [order, setOrder] = useState('asc')
 
-    const handleHeaderClick = (field) => {
+    const handleHeaderClick = field => {
         // There's probably a simpler way to do this...just going between acedning and descending for the query
-        setOrder(order === 'asc' ? 'desc' : order === 'desc' ? 'asc': 'desc')
+        setOrder(order === 'asc' ? 'desc' : order === 'desc' ? 'asc' : 'desc')
         //orderBy is actually our refetch paginated query/function we pass down as props
-        orderBy({order: `${field}:${order}` })
+        orderBy({ order: `${field}:${order}` })
     }
 
     const tableHeaders = [
-        {display: 'Name',
-        field: 'displayName'},
-        {display: 'UID',
-        field: 'id'},
-        {display: 'Level',
-        field: 'level'},
+        { display: 'Name', field: 'displayName' },
+        { display: 'UID', field: 'id' },
+        { display: 'Level', field: 'level' },
         // {display: 'Users',
         // field: 'Users'},
-        {display: 'Geometry Type',
-        field: 'geometry'}
-    ];
+        { display: 'Geometry Type', field: 'geometry' },
+    ]
 
     return (
         <>
@@ -46,7 +42,17 @@ export const OrgUnitTable = ({ orgUnits, orderBy }) => {
                 <Table className={styles.table}>
                     <TableHead>
                         <TableRowHead>
-                            {tableHeaders.map(header => <TableCellHead><span onClick={()=> handleHeaderClick(header.field)}>{i18n.t(header.display)}</span></TableCellHead>)}
+                            {tableHeaders.map(header => (
+                                <TableCellHead key={header.field}>
+                                    <span
+                                        onClick={() =>
+                                            handleHeaderClick(header.field)
+                                        }
+                                    >
+                                        {i18n.t(header.display)}
+                                    </span>
+                                </TableCellHead>
+                            ))}
                             <TableCellHead></TableCellHead>
                         </TableRowHead>
                     </TableHead>
@@ -92,5 +98,6 @@ export const OrgUnitTable = ({ orgUnits, orderBy }) => {
 }
 
 OrgUnitTable.propTypes = {
+    orderBy: PropTypes.func.isRequired,
     orgUnits: PropTypes.array.isRequired,
 }


### PR DESCRIPTION
Added
• Ability to sort table data ascending/descending by headers
• Message to user if search phrase entered does not match any records

Removed
• `User Count` table cell, for now

On a related note, Hacktoberfest just decreed that maintainers need to opt-in: https://hacktoberfest.digitalocean.com/hacktoberfest-update
Spark notes version: PR can be labeled `hacktoberfest-accepted` by maintainers or if the maintainer sets repo topic to `hacktoberfest` it will count. If you wouldn't mind doing one of those two things, that would be great!